### PR TITLE
Allow authentication without a password

### DIFF
--- a/src/Atc.Kepware.Configuration/Services/KepwareConfigurationClient.cs
+++ b/src/Atc.Kepware.Configuration/Services/KepwareConfigurationClient.cs
@@ -80,7 +80,7 @@ public sealed partial class KepwareConfigurationClient : IKepwareConfigurationCl
             BaseAddress = baseUri,
         };
 
-        if (!string.IsNullOrEmpty(userName) && !string.IsNullOrEmpty(password))
+        if (!string.IsNullOrEmpty(userName))
         {
             httpClient.DefaultRequestHeaders.Authorization =
                 new AuthenticationHeaderValue(


### PR DESCRIPTION
Setting an administrator password during installation can be skipped and the 'Default User' account does not seem to have a set password by default. The configuration API does allow for authentication without a password. It is actually very convenient in my development environment that no credentials are required for configuring the kepserver project.