### PR TITLE
feat: get specific device types by channel name

### DIFF
--- a/src/Atc.Kepware.Configuration/GlobalUsings.cs
+++ b/src/Atc.Kepware.Configuration/GlobalUsings.cs
@@ -1,10 +1,13 @@
+global using System.Collections.Concurrent;
 global using System.ComponentModel.DataAnnotations;
 global using System.Diagnostics.CodeAnalysis;
 global using System.Net;
 global using System.Net.Http.Headers;
 global using System.Net.Mime;
+global using System.Reflection;
 global using System.Text;
 global using System.Text.Json;
+global using System.Text.Json.Nodes;
 global using System.Text.Json.Serialization;
 global using Atc.Data.Models;
 global using Atc.Helpers;

--- a/src/Atc.Kepware.Configuration/Services/IKepwareConfigurationClientConnectivity.cs
+++ b/src/Atc.Kepware.Configuration/Services/IKepwareConfigurationClientConnectivity.cs
@@ -91,6 +91,17 @@ public partial interface IKepwareConfigurationClient
         CancellationToken cancellationToken);
 
     /// <summary>
+    /// Returns a list of all devices under the specified channel.
+    /// </summary>
+    /// <param name="channelName">The Channel Name.</param>
+    /// <param name="cancellationToken">The CancellationToken.</param>
+    /// <typeparam name="TDevice">A driver specific <see cref="DeviceBase"/> implementation.</typeparam>
+    Task<HttpClientRequestResult<IList<TDevice>?>> GetDevicesByChannelName<TDevice>(
+        string channelName,
+        CancellationToken cancellationToken)
+        where TDevice : DeviceBase;
+
+    /// <summary>
     /// Returns the properties of the specified EuroMap63 device.
     /// </summary>
     /// <param name="channelName">The Channel Name.</param>


### PR DESCRIPTION
~~Not ready for merging, opened for discussion.~~

Obviously, when getting the devices for a specific channel, all types are going to be the same, since they are all for the same driver. Currently, it is only possible to get all devices for a channel as `DeviceBase`, but not as the specific type for the driver (e.g. `OpcUaClientDevice`). Additional calls are required to get driver specific information for these devices, even though that information was actually already returned from the API in the call to `IKepwareConfigurationClient.GetDevicesByChannelName`.

My use case:
When creating a new simulator device, I want to use a free device id to prevent from sharing an address space with an existing device (see #35). For this, the ids of all existing devices for a simulator channel should be retrieved. Currently, a call to `IKepwareConfigurationClient.GetDevicesByChannelName` is required to determine which devices exist. Subsequently, for each device, a call to `IKepwareConfigurationClient.GetSimulatorDevice` is required to retrieve the configured ids, after which an unused id can be determined.

~~Some performance improvements and exception handling is still to be added, as indicated by the TODO comments.~~
Any suggestions for other improvements?


